### PR TITLE
Added additional properties to manifest

### DIFF
--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -5,8 +5,8 @@ import z from "zod";
 import type { ZodObject } from "zod";
 import type { StringTuple } from "src/types";
 import type { Request, Response } from "express";
-import type { ManifestSpellDetail, Spell } from "src/schemas";
-import { ManifestSpellDetailArraySchema, SpellArraySchema } from "src/schemas";
+import type { SpellSummary, Spell } from "src/schemas";
+import { SpellSummaryArraySchema, SpellArraySchema } from "src/schemas";
 import { toCamel } from "snake-camel";
 
 const DATABASE_FILE_PATH = "database/spellbook.db";
@@ -87,11 +87,11 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-app.get("/manifest", async (_: Request, response: Response) => {
-    const manifest: ManifestSpellDetail[] =
-        ManifestSpellDetailArraySchema.parse(manifestDetails);
-    console.log(arrayToSnakeCase(manifest));
-    response.send(arrayToSnakeCase(manifest));
+app.get("/spellSummaries", async (_: Request, response: Response) => {
+    const spellSummaries: SpellSummary[] =
+        SpellSummaryArraySchema.parse(manifestDetails);
+    console.log(arrayToSnakeCase(spellSummaries));
+    response.send(arrayToSnakeCase(spellSummaries));
 });
 
 app.post("/spells", async (request: Request, response: Response) => {

--- a/back/src/schemas.ts
+++ b/back/src/schemas.ts
@@ -98,7 +98,7 @@ export const SpellSchema = z.object({
 export type Spell = z.infer<typeof SpellSchema>;
 export const SpellArraySchema = z.array(SpellSchema);
 
-export const ManifestSpellDetailSchema = z.object({
+export const SpellSummarySchema = z.object({
     name: z.string(),
     id: z.number(),
     short_description: z.string(),
@@ -134,7 +134,5 @@ export const ManifestSpellDetailSchema = z.object({
     hunter: z.number().nullable(),
     summoner_unchained: z.number().nullable(),
 });
-export type ManifestSpellDetail = z.infer<typeof ManifestSpellDetailSchema>;
-export const ManifestSpellDetailArraySchema = z.array(
-    ManifestSpellDetailSchema
-);
+export type SpellSummary = z.infer<typeof SpellSummarySchema>;
+export const SpellSummaryArraySchema = z.array(SpellSummarySchema);

--- a/front/src/components/SearchResult/SearchResult.tsx
+++ b/front/src/components/SearchResult/SearchResult.tsx
@@ -1,9 +1,9 @@
-import { ManifestSpellDetail } from "schemas";
+import { SpellSummary } from "schemas";
 import StatusButton, { Status } from "components/statusButton/StatusButton";
 import styles from "components/SearchResult/SearchResult.module.css";
 
 type Props = {
-    spell: ManifestSpellDetail;
+    spell: SpellSummary;
     spellbookIds: number[];
     onAddSpell: () => void;
     onRemoveSpell: () => void;

--- a/front/src/components/drawer/browseDrawer/BrowseDrawer.tsx
+++ b/front/src/components/drawer/browseDrawer/BrowseDrawer.tsx
@@ -6,15 +6,15 @@ import ToggleButton from "components/toggleButton/ToggleButton";
 import { useState } from "react";
 import SearchResultsTable from "components/searchResultsTable/SearchResultsTable";
 import Message from "components/message/Message";
-import type { ManifestSpellDetail } from "schemas";
+import type { SpellSummary } from "schemas";
 
 type Props = {
     isOpen: boolean;
     onClose: () => void;
-    spellManifest: ManifestSpellDetail[];
+    spellManifest: SpellSummary[];
     spellbookIds: number[];
-    onAddSpell: (spell: ManifestSpellDetail) => void;
-    onRemoveSpell: (spell: ManifestSpellDetail) => void;
+    onAddSpell: (spell: SpellSummary) => void;
+    onRemoveSpell: (spell: SpellSummary) => void;
 };
 
 const TOGGLE_BUTTON_LEVEL_LABELS = [
@@ -54,7 +54,7 @@ function BrowseDrawer({
         );
     }
 
-    let filteredList: ManifestSpellDetail[] = [];
+    let filteredList: SpellSummary[] = [];
     const query = searchQuery.trim().toLowerCase();
 
     if (query !== "" && query.length >= MINIMUM_QUERY_LENGTH) {

--- a/front/src/components/searchResultsTable/SearchResultsTable.tsx
+++ b/front/src/components/searchResultsTable/SearchResultsTable.tsx
@@ -1,13 +1,13 @@
 import styles from "components/searchResultsTable/SearchResultsTable.module.css";
-import type { ManifestSpellDetail } from "schemas";
+import type { SpellSummary } from "schemas";
 import SearchResult from "components/SearchResult/SearchResult";
 
 type Props = {
-    results: ManifestSpellDetail[];
+    results: SpellSummary[];
     title: string;
     spellbookIds: number[];
-    onAddSpell: (spell: ManifestSpellDetail) => void;
-    onRemoveSpell: (spell: ManifestSpellDetail) => void;
+    onAddSpell: (spell: SpellSummary) => void;
+    onRemoveSpell: (spell: SpellSummary) => void;
 };
 
 function SearchResultsTable({

--- a/front/src/components/spellbookContainer/SpellbookContainer.tsx
+++ b/front/src/components/spellbookContainer/SpellbookContainer.tsx
@@ -6,8 +6,8 @@ import styles from "components/spellbookContainer/SpellbookContainer.module.css"
 import CharacterSettingsDrawer from "components/drawer/charcterSettingsDrawer/CharacterSettingsDrawer";
 import BrowseDrawer from "components/drawer/browseDrawer/BrowseDrawer";
 import MenuDrawer from "components/drawer/menuDrawer/MenuDrawer";
-import { ManifestSpellDetailArraySchema } from "schemas";
-import type { ManifestSpellDetail, Spell } from "schemas";
+import { SpellSummaryArraySchema } from "schemas";
+import type { SpellSummary, Spell } from "schemas";
 import fetchSpells from "remote/fetchSpells";
 import { MANIFEST_ENDPOINT } from "urls";
 
@@ -25,7 +25,7 @@ type Props = {
     onCharacterNameChanged: (characterName: string) => void;
 };
 
-function sortAlphabetically(spells: Spell[] | ManifestSpellDetail[]) {
+function sortAlphabetically(spells: Spell[] | SpellSummary[]) {
     spells.sort((firstSpell, secondSpell) =>
         firstSpell.name.localeCompare(secondSpell.name)
     );
@@ -48,9 +48,7 @@ function SpellbookContainer({
     onCharacterNameChanged,
 }: Props) {
     const [spells, setSpells] = useState<Spell[]>([]);
-    const [spellManifest, setSpellManifest] = useState<ManifestSpellDetail[]>(
-        []
-    );
+    const [spellManifest, setSpellManifest] = useState<SpellSummary[]>([]);
     const [searchQuery, setSearchQuery] = useState<string>("");
     const [spellsLoaded, setSpellsLoaded] = useState<boolean>(false);
     function handleSearchQueryChange(query: string) {
@@ -99,13 +97,12 @@ function SpellbookContainer({
 
         fetch(MANIFEST_ENDPOINT)
             .then((response) => response.json())
-            .then((unvalidatedManifestSpellDetails: ManifestSpellDetail[]) => {
-                const manifestSpellDetails =
-                    ManifestSpellDetailArraySchema.parse(
-                        unvalidatedManifestSpellDetails
-                    );
-                sortAlphabetically(manifestSpellDetails);
-                setSpellManifest(manifestSpellDetails);
+            .then((unvalidatedSpellSummarys: SpellSummary[]) => {
+                const spellSummaries = SpellSummaryArraySchema.parse(
+                    unvalidatedSpellSummarys
+                );
+                sortAlphabetically(spellSummaries);
+                setSpellManifest(spellSummaries);
             });
     }, []);
 
@@ -113,7 +110,7 @@ function SpellbookContainer({
         onSetDrawerState(DrawerState.None);
     }
 
-    function handleAddSpell(requestedSpell: ManifestSpellDetail) {
+    function handleAddSpell(requestedSpell: SpellSummary) {
         if (spells.some((spell) => spell.id === requestedSpell.id)) {
             return;
         }
@@ -121,7 +118,7 @@ function SpellbookContainer({
         requestSpells([requestedSpell.name]);
     }
 
-    function handleRemoveSpell(requestedSpell: ManifestSpellDetail) {
+    function handleRemoveSpell(requestedSpell: SpellSummary) {
         if (!spells.some((spell) => spell.id === requestedSpell.id)) {
             return;
         }

--- a/front/src/schemas.ts
+++ b/front/src/schemas.ts
@@ -96,7 +96,7 @@ export const SpellSchema = z.object({
 export type Spell = z.infer<typeof SpellSchema>;
 export const SpellArraySchema = z.array(SpellSchema);
 
-export const ManifestSpellDetailSchema = z.object({
+export const SpellSummarySchema = z.object({
     name: z.string(),
     id: z.number(),
     shortDescription: z.string(),
@@ -132,7 +132,5 @@ export const ManifestSpellDetailSchema = z.object({
     hunter: z.number().nullable(),
     summonerUnchained: z.number().nullable(),
 });
-export type ManifestSpellDetail = z.infer<typeof ManifestSpellDetailSchema>;
-export const ManifestSpellDetailArraySchema = z.array(
-    ManifestSpellDetailSchema
-);
+export type SpellSummary = z.infer<typeof SpellSummarySchema>;
+export const SpellSummaryArraySchema = z.array(SpellSummarySchema);


### PR DESCRIPTION
# Problem
- The spell table was making a full network request for the spells each time it needed to display the upfront values for each spell. 
- Additionally, browse was limited in what we could filter by.

# Solution
We included extra properties into the manifest which should allow for more flexibility in the search table and browse drawer.