### PR TITLE
Cleaned up dev scripts

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -27,5 +27,5 @@ COPY /src /app/src
 COPY /bin /app/bin
 # yarn restart builds a new database, even if one already exists. It then runs
 # via ts-node, without live-reload. This happens during image build, before container startup.
-RUN ["yarn", "build-production"]
+RUN ["yarn", "setup-database"]
 ENTRYPOINT ["yarn", "start-production"]

--- a/back/bin/build_production.sh
+++ b/back/bin/build_production.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-cd ../src/database/
-
-echo "Creating database."
-ts-node setup.ts
-echo "Populating database (this can take a while)."
-ts-node populateDatabase.ts
-echo "Database setup complete!"

--- a/back/bin/restart.sh
+++ b/back/bin/restart.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-rm ../src/database/spellbook.db
-./start.sh
+WORKDIR=$1
+
+rm "${WORKDIR}/src/database/spellbook.db"
+bash "${WORKDIR}/bin/start.sh" "${WORKDIR}"

--- a/back/bin/setup_database.sh
+++ b/back/bin/setup_database.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 
-cd ../src/database/
+WORKDIR=$1
 
 echo "Creating database."
-ts-node setup.ts
+ts-node "${WORKDIR}/src/database/setup.ts"
 echo "Populating database (this can take a while)."
-ts-node populateDatabase.ts
-echo "Database setup complete!"
-
-cd ../../bin/
+ts-node "${WORKDIR}/src/database/populateDatabase.ts"
+echo "Database setup complete"

--- a/back/bin/start.sh
+++ b/back/bin/start.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-DB_PATH='../src/database/spellbook.db'
+WORKDIR=$1
+
+DB_PATH="${WORKDIR}/src/database/spellbook.db"
 
 if [ ! -f "$DB_PATH" ]; then
-    ./setup_database.sh
+    bash "${WORKDIR}/bin/setup_database.sh" "${WORKDIR}"
 fi
 
-cd ../src/
-
-nodemon index.ts
+nodemon "${WORKDIR}/src/index.ts"

--- a/back/bin/start_production.sh
+++ b/back/bin/start_production.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-cd ../src/
+WORKDIR=$1
 
-ts-node index.ts
+ts-node "${WORKDIR}/src/index.ts"

--- a/back/package.json
+++ b/back/package.json
@@ -29,10 +29,10 @@
         "zod": "^3.24.1"
     },
     "scripts": {
-        "restart": "cd bin/ && ./restart.sh",
-        "start": "cd bin/ && ./start.sh",
-        "build-production": "cd bin/ && ./build_production.sh",
-        "start-production": "cd bin/ && ./start_production.sh",
+        "restart": "bash ./bin/restart.sh $(pwd)",
+        "start": "bash ./bin/start.sh $(pwd)",
+        "setup-database": "bash ./bin/setup_database.sh $(pwd)",
+        "start-production": "bash ./bin/start_production.sh $(pwd)",
         "manual-test": "ts-node src/testing/manual.ts",
         "lint": "eslint ."
     },

--- a/back/src/database/populateDatabase.ts
+++ b/back/src/database/populateDatabase.ts
@@ -3,8 +3,8 @@ import fs from "fs";
 import csv from "csv-parser";
 import z from "zod";
 
-const DATABASE_FILE_PATH = "spellbook.db";
-const INITIAL_CSV_FILE_PATH = "./spellbook.csv";
+const DATABASE_FILE_PATH = "./src/database/spellbook.db";
+const INITIAL_CSV_FILE_PATH = "./src/database/spellbook.csv";
 const CSV_FALSE = "0";
 const CSV_TRUE = "1";
 const STRING_NULL = "NULL";

--- a/back/src/database/setup.ts
+++ b/back/src/database/setup.ts
@@ -1,8 +1,8 @@
 import sqlite3 from "sqlite3";
 import fs from "fs";
 
-const DATABASE_FILE_PATH = "spellbook.db"
-const DATABASE_SETUP_FILE = "./setup.sql"
+const DATABASE_FILE_PATH = "./src/database/spellbook.db"
+const DATABASE_SETUP_FILE = "./src/database/setup.sql"
 
 const database = new sqlite3.Database(DATABASE_FILE_PATH)
 

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -9,7 +9,7 @@ import type { SpellSummary, Spell } from "src/types";
 import { SpellSummaryArraySchema, SpellArraySchema } from "src/schemas";
 import { toCamel } from "snake-camel";
 
-const DATABASE_FILE_PATH = "database/spellbook.db";
+const DATABASE_FILE_PATH = "./src/database/spellbook.db";
 const ERROR_STATUS_CLIENT = 400;
 const PORT = process.env.NODE_ENV === "production" ? 80 : 3000;
 const TABLE_NAME = "d20pfsrd";

--- a/kill-dev.sh
+++ b/kill-dev.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+WORKDIR=`pwd`
+
 tmux kill-session -t spellbookdev
+
+(cd ${WORKDIR}/back; docker compose down)


### PR DESCRIPTION
# Problem
- The `kill-dev.sh` script wasn't bringing down the docker containers
- The dev scripts were using relative paths. This is a problem when you have wrapper scripts, as each script expects to be in a certain directory, and so it becomes a mess trying to figure out where you are.

# Solution
- We now run `docker compose down` in a subshell.
- We use a `WORKDIR` variable to provide us with an absolute path.