### PR TITLE
Added health check endpoint

### DIFF
--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -87,6 +87,10 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+app.get("/healthCheck", async (_: Request, response: Response) => {
+    response.sendStatus(200);
+});
+
 app.get("/spellSummaries", async (_: Request, response: Response) => {
     const spellSummaries: SpellSummary[] =
         SpellSummaryArraySchema.parse(manifestDetails);


### PR DESCRIPTION
# What
- Added in an empty endpoint that simply returns `200 OK`.

# Why
- AWS performs regular health checks on the server instances, and it would be nice to have a lightweight endpoint it can ping.