### PR TITLE
Updated to use production url on build

### DIFF
--- a/front/src/urls.tsx
+++ b/front/src/urls.tsx
@@ -1,5 +1,12 @@
 export const BACKEND_PORT = "3000";
-export const BACKEND_BASE_URL = `http://localhost:${BACKEND_PORT}`;
+export const DEVELOPMENT_BACKEND_BASE_URL = `http://localhost:${BACKEND_PORT}`;
+export const PRODUCTION_BACKEND_BASE_URL =
+    "https://q3tip87tp2.ap-southeast-2.awsapprunner.com/";
+
+export const BACKEND_BASE_URL = import.meta.env.DEV
+    ? DEVELOPMENT_BACKEND_BASE_URL
+    : PRODUCTION_BACKEND_BASE_URL;
+
 export const SPELL_SUMMARIES_ENDPOINT = new URL(
     "spellSummaries",
     BACKEND_BASE_URL


### PR DESCRIPTION
# What
- Added in a production url from AWS AppRunner.
- Added in the ability to use the new production url when the application is built via `vite build`.

# Why
- We want to be using the production URL on AWS when we deploy a production version of the front end.