### PR TITLE
Changed spellbookId to spellId

### DIFF
--- a/front/src/components/drawer/browseDrawer/BrowseDrawer.tsx
+++ b/front/src/components/drawer/browseDrawer/BrowseDrawer.tsx
@@ -15,7 +15,7 @@ type Props = {
     spellSummaries: SpellSummary[];
     spellSummariesLoaded: boolean;
     character: Character;
-    spellbookIds: number[];
+    spellIds: number[];
     onAddSpell: (spell: SpellSummary) => void;
     onRemoveSpell: (spell: SpellSummary) => void;
 };
@@ -43,7 +43,7 @@ function BrowseDrawer({
     onClose,
     spellSummaries,
     spellSummariesLoaded,
-    spellbookIds,
+    spellIds,
     character,
     onAddSpell,
     onRemoveSpell,
@@ -132,7 +132,7 @@ function BrowseDrawer({
                     <SearchResultsTable
                         results={filteredListsByLevel[levelIndex]}
                         title={levelTitle}
-                        spellbookIds={spellbookIds}
+                        spellIds={spellIds}
                         onAddSpell={onAddSpell}
                         onRemoveSpell={onRemoveSpell}
                         key={levelIndex}
@@ -146,7 +146,7 @@ function BrowseDrawer({
                 <SearchResultsTable
                     results={uncategorisedList}
                     title={"Uncategorised"}
-                    spellbookIds={spellbookIds}
+                    spellIds={spellIds}
                     onAddSpell={onAddSpell}
                     onRemoveSpell={onRemoveSpell}
                     key={UNCATEGORISED_LEVEL}

--- a/front/src/components/searchResult/SearchResult.tsx
+++ b/front/src/components/searchResult/SearchResult.tsx
@@ -4,29 +4,24 @@ import styles from "components/searchResult/SearchResult.module.css";
 
 type Props = {
     spell: SpellSummary;
-    spellbookIds: number[];
+    spellIds: number[];
     onAddSpell: () => void;
     onRemoveSpell: () => void;
 };
 
-function SearchResult({
-    spell,
-    spellbookIds,
-    onAddSpell,
-    onRemoveSpell,
-}: Props) {
+function SearchResult({ spell, spellIds, onAddSpell, onRemoveSpell }: Props) {
     return (
         <div className={styles.searchResult}>
             <div className={styles.spellName}>
                 <span className="symbol">
-                    {spellbookIds.includes(spell.id) && "book_4_spark"}
+                    {spellIds.includes(spell.id) && "book_4_spark"}
                 </span>
                 <p>{spell.name}</p>
             </div>
             <div className={styles.addButtonContainer}>
                 <StatusButton
                     status={
-                        !spellbookIds.includes(spell.id)
+                        !spellIds.includes(spell.id)
                             ? Status.First
                             : Status.Second
                     }

--- a/front/src/components/searchResultsTable/SearchResultsTable.tsx
+++ b/front/src/components/searchResultsTable/SearchResultsTable.tsx
@@ -5,7 +5,7 @@ import SearchResult from "components/searchResult/SearchResult";
 type Props = {
     results: SpellSummary[];
     title: string;
-    spellbookIds: number[];
+    spellIds: number[];
     onAddSpell: (spell: SpellSummary) => void;
     onRemoveSpell: (spell: SpellSummary) => void;
 };
@@ -13,7 +13,7 @@ type Props = {
 function SearchResultsTable({
     results,
     title,
-    spellbookIds,
+    spellIds,
     onAddSpell,
     onRemoveSpell,
 }: Props) {
@@ -26,7 +26,7 @@ function SearchResultsTable({
             {results.map((spell, index) => (
                 <SearchResult
                     spell={spell}
-                    spellbookIds={spellbookIds}
+                    spellIds={spellIds}
                     onAddSpell={() => onAddSpell(spell)}
                     onRemoveSpell={() => onRemoveSpell(spell)}
                     key={index}

--- a/front/src/components/spellbookContainer/SpellbookContainer.tsx
+++ b/front/src/components/spellbookContainer/SpellbookContainer.tsx
@@ -138,7 +138,7 @@ function SpellbookContainer({
                 spellSummaries={spellSummaries}
                 spellSummariesLoaded={spellSummariesLoaded}
                 character={character}
-                spellbookIds={spells.map((spell) => spell.id)}
+                spellIds={spells.map((spell) => spell.id)}
                 onAddSpell={handleAddSpell}
                 onRemoveSpell={handleRemoveSpell}
             />


### PR DESCRIPTION
# What
- Changed `spellbookId` to `spellId`.

# Why
- It didn't make sense ot call it `spellbookId`, when it was just the Id of the spell.