### PR TITLE
Fixed up local storage caching

### DIFF
--- a/front/src/components/spellbookContainer/SpellbookContainer.tsx
+++ b/front/src/components/spellbookContainer/SpellbookContainer.tsx
@@ -58,9 +58,12 @@ function SpellbookContainer({
         SPELLS_KEY,
         []
     );
-    const [spellSummaries, setSpellSummaries] = useStateWithLocalStorage<
-        SpellSummary[]
-    >(SPELL_SUMMARIES_KEY, []);
+    const [
+        spellSummaries,
+        setSpellSummaries,
+        spellSummariesLoadedFromLocalStorage,
+    ] = useStateWithLocalStorage<SpellSummary[]>(SPELL_SUMMARIES_KEY, []);
+
     // When we keep track of users' spells in the backend, this will
     // be more meaningful, until then assume spells are always insta-loaded
     // since local storage is our only source of truth here
@@ -68,15 +71,20 @@ function SpellbookContainer({
     const [spellSummariesLoaded, setSpellSummariesLoaded] =
         useState<boolean>(false);
     const [searchQuery, setSearchQuery] = useState<string>("");
+
     useEffect(() => {
-        if (!spellSummariesLoaded) {
+        if (!spellSummariesLoaded && !spellSummariesLoadedFromLocalStorage) {
             fetchSpellSummaries().then((fetchedSpellSummaries) => {
                 sortAlphabetically(fetchedSpellSummaries);
                 setSpellSummaries(fetchedSpellSummaries);
                 setSpellSummariesLoaded(true);
             });
         }
-    }, [spellSummariesLoaded, setSpellSummaries]);
+    }, [
+        spellSummariesLoaded,
+        setSpellSummaries,
+        spellSummariesLoadedFromLocalStorage,
+    ]);
 
     function handleCloseDrawer() {
         onSetDrawerState(DrawerState.None);

--- a/front/src/components/spellbookContainer/SpellbookContainer.tsx
+++ b/front/src/components/spellbookContainer/SpellbookContainer.tsx
@@ -68,23 +68,31 @@ function SpellbookContainer({
     // be more meaningful, until then assume spells are always insta-loaded
     // since local storage is our only source of truth here
     const [spellsLoaded] = useState<boolean>(true);
-    const [spellSummariesLoaded, setSpellSummariesLoaded] =
-        useState<boolean>(false);
+    const [
+        spellSummariesLoadedFromNetwork,
+        setSpellSummariesLoadedFromNetwork,
+    ] = useState<boolean>(false);
     const [searchQuery, setSearchQuery] = useState<string>("");
 
     useEffect(() => {
-        if (!spellSummariesLoaded && !spellSummariesLoadedFromLocalStorage) {
+        if (
+            !spellSummariesLoadedFromNetwork &&
+            !spellSummariesLoadedFromLocalStorage
+        ) {
             fetchSpellSummaries().then((fetchedSpellSummaries) => {
                 sortAlphabetically(fetchedSpellSummaries);
                 setSpellSummaries(fetchedSpellSummaries);
-                setSpellSummariesLoaded(true);
+                setSpellSummariesLoadedFromNetwork(true);
             });
         }
     }, [
-        spellSummariesLoaded,
+        spellSummariesLoadedFromNetwork,
         setSpellSummaries,
         spellSummariesLoadedFromLocalStorage,
     ]);
+
+    const spellSummariesLoaded =
+        spellSummariesLoadedFromNetwork || spellSummariesLoadedFromLocalStorage;
 
     function handleCloseDrawer() {
         onSetDrawerState(DrawerState.None);


### PR DESCRIPTION
# What
- Fixed up `spellSummaries` to properly use the local storage caching, meaning it won't make a network request if the `spellSummaries` were loaded from local storage.

# Why
- There was a bug where it was making a network request every time, even if it managed to retrieve `spellSummaries` from local storage.