### PR TITLE
Increase contrast on table rows in light mode

### DIFF
--- a/front/src/components/spellTable/SpellTable.module.css
+++ b/front/src/components/spellTable/SpellTable.module.css
@@ -20,20 +20,18 @@
 .spellTable tbody tr:hover {
     cursor: pointer;
     /* background-color: var(--medium-accent-colour); */
-
 }
 
 .spellTable td {
     padding: 0.1rem 1rem 0.1rem 2.5rem;
 }
 
-
 .spellTable tr:nth-child(odd) {
     background-color: var(--background-colour);
 }
 
 .spellTable tr:nth-child(even) {
-    background-color: var(--light-accent-colour);
+    background-color: var(--medium-accent-colour);
 }
 
 .spellTable tr:hover {


### PR DESCRIPTION
# What
- Increased the accent colour for even numbered rows from `light-accent-color` to `medium-accent-color`.

# Why
- It was difficult to distinguish apart different rows.