### PR TITLE
Separated out front and backend pipelines and used paths

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,12 +3,10 @@ name: Lint
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch
-  push:
+  [push, pull_request]:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+    paths: "/front/**"
 
 jobs:
   run-linter-frontend:
@@ -17,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: ./front
-        
+
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
@@ -29,33 +27,7 @@ jobs:
 
       - name: Install yarn
         run: npm install yarn
-      
-      # ESLint and Prettier must be in `package.json`
-      - name: Install Node.js dependencies
-        run: yarn
 
-      - name: Run linters
-        run: yarn lint
-          
-  run-linter-backend:
-    name: Run linter on the backend
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./back
-    
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
-  
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 23
-
-      - name: Install yarn
-        run: npm install yarn
-      
       # ESLint and Prettier must be in `package.json`
       - name: Install Node.js dependencies
         run: yarn

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,12 +1,14 @@
-name: Lint
+name: Backend
 
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
-  [push, pull_request]:
+  push:
     branches:
       - main
-    paths: "/front/**"
+    paths: "/back/**"
+  pull_request:
+    branches:
+      - main
+    paths: "/back/**"
 
 jobs:
   run-linter-frontend:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-    paths: "/back/**"
+    paths: "/front/**"
   pull_request:
     branches:
       - main
-    paths: "/back/**"
+    paths: "/front/**"
 
 jobs:
   run-linter-frontend:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,12 +1,14 @@
-name: Lint
+name: Frontend
 
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
-  [push, pull_request]:
+  push:
     branches:
       - main
-    paths: "/front/**"
+    paths: "/back/**"
+  pull_request:
+    branches:
+      - main
+    paths: "/back/**"
 
 jobs:
   run-linter-frontend:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  [push, pull_request]:
+    branches:
+      - main
+    paths: "/front/**"
+
+jobs:
+  run-linter-frontend:
+    name: Run linter on the frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./front
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 23
+
+      - name: Install yarn
+        run: npm install yarn
+
+      # ESLint and Prettier must be in `package.json`
+      - name: Install Node.js dependencies
+        run: yarn
+
+      - name: Run linters
+        run: yarn lint


### PR DESCRIPTION
# What
- Separated out the lint workflow into a two separate workflows, one for the frontend and one for the backend.
- Uses Github Action "paths" to only trigger the corresponding pipeline based on what changes have been made. e.g, only the front end pipeline will run if only frontend changes have been made.

# Why
- Makes CI faster by only running the necessary jobs.