### PR TITLE
Separated out spell table and update population scripts

### DIFF
--- a/back/src/database/populateDatabase.ts
+++ b/back/src/database/populateDatabase.ts
@@ -8,7 +8,7 @@ const INITIAL_CSV_FILE_PATH = "./src/database/spellbook.csv";
 const CSV_FALSE = "0";
 const CSV_TRUE = "1";
 const STRING_NULL = "NULL";
-const TABLE_NAME = "d20pfsrd";
+const SPELLS_TABLE_NAME = "spells_d20pfsrd";
 
 const database = new sqlite3.Database(DATABASE_FILE_PATH);
 
@@ -33,7 +33,7 @@ const stringFromStringOrNull = z.string().transform((val) => {
     return val;
 });
 
-const D20PfsrdSpellSchema = z.object({
+const D20pfsrdSpellSchema = z.object({
     name: stringFromStringOrNull,
     school: stringFromStringOrNull,
     subschool: stringFromStringOrNull,
@@ -125,15 +125,15 @@ const D20PfsrdSpellSchema = z.object({
     augmented: stringFromStringOrNull,
     haunt_statistics: stringFromStringOrNull,
 });
-type D20PfsrdSpell = z.infer<typeof D20PfsrdSpellSchema>;
+type D20pfsrdSpell = z.infer<typeof D20pfsrdSpellSchema>;
 
 function main() {
-    const spells: D20PfsrdSpell[] = [];
+    const spells: D20pfsrdSpell[] = [];
 
     fs.createReadStream(INITIAL_CSV_FILE_PATH)
         .pipe(csv())
         .on("data", (data: { [key: string]: string }) => {
-            const validatedData = D20PfsrdSpellSchema.parse(data);
+            const validatedData = D20pfsrdSpellSchema.parse(data);
             spells.push(validatedData);
         })
         .on("end", () => {
@@ -141,14 +141,14 @@ function main() {
         });
 }
 
-function insertIntoDatabase(spells: D20PfsrdSpell[]) {
+function insertIntoDatabase(spells: D20pfsrdSpell[]) {
     for (const spell of spells) {
         const columnNames = Object.keys(spell).join(", ");
         const valueIndexes = Object.values(spell)
             .map((_, index) => `$${index + 1}`)
             .join(", ");
         const query = `
-            INSERT INTO ${TABLE_NAME} (
+            INSERT INTO ${SPELLS_TABLE_NAME} (
                 ${columnNames}
             ) VALUES (
                 ${valueIndexes}

--- a/back/src/database/setup.sql
+++ b/back/src/database/setup.sql
@@ -1,8 +1,8 @@
 -- Setup the database structure and tables
 
 
--- Create table for the d20pfsrd data.
-CREATE TABLE IF NOT EXISTS d20pfsrd (
+-- Create table for the d20pfsrf spell data.
+CREATE TABLE IF NOT EXISTS spells_d20pfsrd (
     id INTEGER PRIMARY KEY,
     name TEXT NOT NULL,
     school TEXT NOT NULL,

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -12,7 +12,7 @@ import { toCamel } from "snake-camel";
 const DATABASE_FILE_PATH = "./src/database/spellbook.db";
 const ERROR_STATUS_CLIENT = 400;
 const PORT = process.env.NODE_ENV === "production" ? 443 : 3000;
-const TABLE_NAME = "d20pfsrd";
+const SPELLS_TABLE_NAME = "spells_d20pfsrd";
 const NAME_COLUMN = "name";
 const DATABASE_PLACEHOLDER_CHARACTER = "?";
 
@@ -28,7 +28,7 @@ let validSpellNames: string[] = [];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let SpellRequestSchema: ZodObject<any>;
 database.all(
-    `SELECT ${NAME_COLUMN} FROM ${TABLE_NAME};`,
+    `SELECT ${NAME_COLUMN} FROM ${SPELLS_TABLE_NAME};`,
     (_, rows: { [key: string]: string }[]) => {
         validSpellNames = rows.map((spell) => spell.name);
         SpellRequestSchema = z.object({
@@ -76,7 +76,7 @@ database.all(
             hunter,
             summoner_unchained
         FROM
-            ${TABLE_NAME};
+            ${SPELLS_TABLE_NAME};
     `,
     (_, rows: { [key: string]: string | number | null }[]) => {
         manifestDetails = rows;
@@ -92,8 +92,7 @@ app.get("/healthCheck", async (_: Request, response: Response) => {
 });
 
 app.get("/spellSummaries", async (_: Request, response: Response) => {
-    const spellSummaries: SpellSummary[] =
-        SpellSummaryArraySchema.parse(manifestDetails);
+    const spellSummaries: SpellSummary[] = SpellSummaryArraySchema.parse(manifestDetails);
     console.log(arrayToSnakeCase(spellSummaries));
     response.send(arrayToSnakeCase(spellSummaries));
 });
@@ -133,13 +132,11 @@ app.listen(PORT, () => {
 async function queryDatabaseForSpells(
     spellNames: string[]
 ): Promise<{ [key: string]: string | number | null }[]> {
-    const placeholder_values = spellNames.map(
-        () => DATABASE_PLACEHOLDER_CHARACTER
-    );
+    const placeholder_values = spellNames.map(() => DATABASE_PLACEHOLDER_CHARACTER);
 
     return new Promise((resolve, reject) => {
         database.all(
-            `SELECT * FROM ${TABLE_NAME} WHERE name IN (${placeholder_values.join(
+            `SELECT * FROM ${SPELLS_TABLE_NAME} WHERE name IN (${placeholder_values.join(
                 ", "
             )})`,
             spellNames,


### PR DESCRIPTION
# What
- Changed the table `d20pfsrd` to `spells_d20pfsrd`.
- Updated population scripts to use the new `spells_d20pfsrd` table.

# Why
- We're eventually going to need to use other data from `d20pfsrd`. E.g. Monsters, Classes, Items, and etc. This means it doesn't make sense to have a single table called `d20pfsrd` that is only dedicated to spells.