### PR TITLE
Created new directory and page component

### DIFF
--- a/front/src/pages/Page.tsx
+++ b/front/src/pages/Page.tsx
@@ -1,0 +1,24 @@
+import Header from "components/header/Header";
+import { DrawerState } from "components/spellbook/Spellbook";
+import { Character } from "types";
+
+type Props = {
+    children: React.ReactNode;
+    currentCharacter: Character;
+    toggleDrawerState: (targetState: DrawerState) => void;
+};
+
+function Page({ children, currentCharacter, toggleDrawerState }: Props) {
+    return (
+        <>
+            <Header
+                characterName={currentCharacter.name}
+                onToggleMenu={() => toggleDrawerState(DrawerState.Menu)}
+                onToggleSettings={() => toggleDrawerState(DrawerState.Settings)}
+            />
+            {children}
+        </>
+    );
+}
+
+export default Page;


### PR DESCRIPTION
# What
- Creates a new directory to contain Pages.
- Introduces a new parent component `Page` (currently unused) that will hold all common components and data in various pages.

# Why
- We're eventually going to want different pages for different reasons, and so we should set our codebase up to work with routes early on.
- We also want to improve our separation of concerns, and ensure that `App.tsx` is only used for configuration and not business logic. This sets the groundwork for moving data out of `App.tsx`.
- Additionally, we also want to only keep orchestration logic in the various Page components we define, and so knowing what components are "Pages" will allow us to move implementation logic out of those components and into the children.